### PR TITLE
auth: Add flow for authentication on CLI

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,15 +1,31 @@
 import os
 import typer
 from dotenv import load_dotenv
-load_dotenv()
+from pathlib import Path
+try:
+    config_path = Path(os.environ["GG_PATH"])
+except Exception:
+    config_path = Path.home().joinpath(".gg")
+finally:
+    if config_path.is_file():
+        load_dotenv(config_path)
 
 try:
     access_token = os.environ["GG_PAT"]
 except Exception:
     typer.secho(
-        "Cannot find GitHub personal access token to authenticate",
+        "Uh-oh, cannot find your GitHub personal access token to authenticate. 😓",
         err=True, fg=typer.colors.RED)
-    raise typer.Exit(1)
+    typer.echo((
+        "ℹ You can fetch or generate a new token from https://github.com/settings/tokens\n"
+        "You will need to grant the repo, notification, user scopes for gitgood to work properly."
+    ))
+    access_token = typer.prompt(
+        "Enter your personal access token to continue (for safety, it won't show)",
+        hide_input=True)
+    with open(Path.home().joinpath(".gg"), "a+") as file:
+        file.write(f"GG_PAT={access_token}")
+    typer.secho("Your token has been stored successfully. 🚀", fg=typer.colors.GREEN, bold=True)
 
 
 def main():


### PR DESCRIPTION
Fixes #3 

## Summary
* Add support to load configuration from a `.gg` file or any path specified in an environment variable called `GG_PATH`.
* Add support to load GitHub token from environment variable or create (or add) it using a flow on the CLI.

## Screenshot
(the emojis are small because Windows Terminal 😢)
![image](https://user-images.githubusercontent.com/1272002/99667317-3d7b1380-2a92-11eb-83e3-00c9e0b37092.png)